### PR TITLE
Initializer blueprint should reflex accurate params

### DIFF
--- a/blueprints/initializer/files/__root__/initializers/__name__.js
+++ b/blueprints/initializer/files/__root__/initializers/__name__.js
@@ -1,4 +1,4 @@
-export function initialize(/* application */) {
+export function initialize(/* registry, application */) {
   // application.inject('route', 'foo', 'service:foo');
 }
 


### PR DESCRIPTION
The commented parameters are not accurate. For developer clarity, show that the first param is registry, and the application is second.
